### PR TITLE
Fix panic on double space

### DIFF
--- a/jobs/txt2img.go
+++ b/jobs/txt2img.go
@@ -65,7 +65,7 @@ func removeCommands(msg string) string {
 	words := strings.Split(msg, " ")
 
 	for _, w := range words {
-		if w[0] == byte('/') {
+		if len(w) > 0 && w[0] == byte('/') {
 			msg = strings.ReplaceAll(msg, w, "")
 		}
 	}
@@ -76,7 +76,7 @@ func removeMentions(msg string) string {
 	words := strings.Split(msg, " ")
 
 	for _, w := range words {
-		if w[0] == byte('@') {
+		if len(w) > 0 && w[0] == byte('@') {
 			msg = strings.ReplaceAll(msg, w, "")
 		}
 	}

--- a/jobs/txt2img_test.go
+++ b/jobs/txt2img_test.go
@@ -4,9 +4,7 @@ import (
 	"testing"
 )
 
-// TestClean calls clean and checks different cases
 func TestClean(t *testing.T) {
-
 	tests := []struct {
 		prompt   string
 		expected string
@@ -19,13 +17,12 @@ func TestClean(t *testing.T) {
 	for _, tt := range tests {
 		msg := clean(tt.prompt)
 		if msg != tt.expected {
-			t.Fatalf(`Hello("") = %q, want %q, error`, msg, tt.expected)
+			t.Fatalf(`Got = %q, want %q, error`, msg, tt.expected)
 		}
 	}
 }
 
 func TestRemoveMentions(t *testing.T) {
-
 	tests := []struct {
 		prompt   string
 		expected string
@@ -38,13 +35,12 @@ func TestRemoveMentions(t *testing.T) {
 	for _, tt := range tests {
 		msg := removeMentions(tt.prompt)
 		if msg != tt.expected {
-			t.Fatalf(`Hello("") = %q, want %q, error`, msg, tt.expected)
+			t.Fatalf(`Got = %q, want %q, error`, msg, tt.expected)
 		}
 	}
 }
 
 func TestRemoveCommands(t *testing.T) {
-
 	tests := []struct {
 		prompt   string
 		expected string
@@ -57,7 +53,7 @@ func TestRemoveCommands(t *testing.T) {
 	for _, tt := range tests {
 		msg := removeCommands(tt.prompt)
 		if msg != tt.expected {
-			t.Fatalf(`Hello("") = %q, want %q, error`, msg, tt.expected)
+			t.Fatalf(`Got = %q, want %q, error`, msg, tt.expected)
 		}
 	}
 }

--- a/jobs/txt2img_test.go
+++ b/jobs/txt2img_test.go
@@ -1,0 +1,63 @@
+package jobs
+
+import (
+	"testing"
+)
+
+// TestClean calls clean and checks different cases
+func TestClean(t *testing.T) {
+
+	tests := []struct {
+		prompt   string
+		expected string
+	}{
+		{"", ""},
+		{"valid test", "valid test"},
+		{"valid test   with    extra    spaces", "valid test with extra spaces"},
+	}
+
+	for _, tt := range tests {
+		msg := clean(tt.prompt)
+		if msg != tt.expected {
+			t.Fatalf(`Hello("") = %q, want %q, error`, msg, tt.expected)
+		}
+	}
+}
+
+func TestRemoveMentions(t *testing.T) {
+
+	tests := []struct {
+		prompt   string
+		expected string
+	}{
+		{"", ""},
+		{"valid test", "valid test"},
+		{"valid test with @mentions in the middle", "valid test with  in the middle"},
+	}
+
+	for _, tt := range tests {
+		msg := removeMentions(tt.prompt)
+		if msg != tt.expected {
+			t.Fatalf(`Hello("") = %q, want %q, error`, msg, tt.expected)
+		}
+	}
+}
+
+func TestRemoveCommands(t *testing.T) {
+
+	tests := []struct {
+		prompt   string
+		expected string
+	}{
+		{"", ""},
+		{"valid test", "valid test"},
+		{"valid test with /commands in the middle", "valid test with  in the middle"},
+	}
+
+	for _, tt := range tests {
+		msg := removeCommands(tt.prompt)
+		if msg != tt.expected {
+			t.Fatalf(`Hello("") = %q, want %q, error`, msg, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
Fix wrong behavior when there is a double space and other similar statuses that ends up in a empty word when checking for specific characters.

Also adding tests to those functions.