### PR TITLE
Remove support for local generators

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.env
+cSpell.json
+Dockerfile
+justfile
+README

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.21-alpine3.18
+COPY . /app
+WORKDIR /app
+RUN go build -o botatobot cmd/botatobot/main.go
+CMD [ "./botatobot" ]

--- a/cmd/botatobot/main.go
+++ b/cmd/botatobot/main.go
@@ -8,6 +8,7 @@ import (
 	"scristobal/botatobot/pkg"
 
 	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
 )
 
 func main() {
@@ -23,13 +24,17 @@ func main() {
 	}
 
 	botato.RegisterHandler(bot.HandlerTypeMessageText, string(pkg.GenerateCommand), bot.MatchTypePrefix, pkg.GenerateHandler)
-	botato.RegisterHandler(bot.HandlerTypeMessageText, string(pkg.HelpCommand), bot.MatchTypePrefix, pkg.HelpHandler)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
 	generator := pkg.NewImageGenerator()
 	ctx = context.WithValue(ctx, pkg.ImageGeneratorKey, generator)
+
+	botato.SetMyCommands(ctx, &bot.SetMyCommandsParams{Commands: []models.BotCommand{{
+		Command:     string(pkg.GenerateCommand),
+		Description: "Generate an image from a prompt",
+	}}})
 
 	go botato.Start(ctx)
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,21 @@
+# fly.toml app configuration file generated for botatobot on 2023-11-19T17:03:52+01:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "botatobot"
+primary_region = "mad"
+
+[build]
+
+[http_service]
+internal_port = 8080
+force_https = true
+auto_stop_machines = true
+auto_start_machines = true
+min_machines_running = 0
+processes = ["app"]
+
+[env]
+LOCAL_PORT = "8080"
+REPLICATE_VERSION = "39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b"

--- a/fly.toml
+++ b/fly.toml
@@ -18,4 +18,3 @@ processes = ["app"]
 
 [env]
 LOCAL_PORT = "8080"
-REPLICATE_VERSION = "39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b"

--- a/pkg/env.go
+++ b/pkg/env.go
@@ -11,8 +11,6 @@ import (
 var (
 	LOCAL_PORT        string
 	TELEGRAMBOT_TOKEN string
-	MODEL_URL         string
-	OUTPUT_PATH       string
 	REPLICATE_URL     string
 	REPLICATE_TOKEN   string
 	REPLICATE_VERSION string
@@ -39,20 +37,6 @@ func FromEnv() error {
 		return fmt.Errorf("BOT_TOKEN not found. Talk to @botfather in Telegram and get one")
 	}
 
-	OUTPUT_PATH, ok = os.LookupEnv("OUTPUT_PATH")
-
-	if !ok {
-		log.Println("OUTPUT_PATH not found, files will not be saved locally.")
-	}
-
-	MODEL_URL, ok = os.LookupEnv("MODEL_URL")
-
-	if ok {
-		return nil
-	}
-
-	log.Println("MODEL_URL not found, loading replicate.com config.")
-
 	REPLICATE_URL, ok = os.LookupEnv("REPLICATE_URL")
 
 	if !ok {
@@ -70,7 +54,8 @@ func FromEnv() error {
 	REPLICATE_VERSION, ok = os.LookupEnv("REPLICATE_VERSION")
 
 	if !ok {
-		return fmt.Errorf("REPLICATE_VERSION not found, go to replicate.com and choose a model version")
+		REPLICATE_VERSION = "39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b"
+		log.Printf("REPLICATE_VERSION not found, using default %s\n", REPLICATE_VERSION)
 	}
 
 	return nil

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -1,11 +1,9 @@
 package pkg
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -27,28 +25,46 @@ func NewImageGenerator() *imageGenerator {
 	}
 }
 
-func (g *imageGenerator) GenerateImageFromPrompt(prompt string) ([]byte, error) {
+func (g *imageGenerator) GenerateImageFromPrompt(prompt string) ([]string, error) {
 
-	input := modelInput{
-		Prompt:              prompt,
-		Seed:                rand.Intn(1_000_00),
-		Num_inference_steps: 50,
-		Guidance_scale:      7.5,
+	modelInput := modelInput{
+		Prompt:               prompt,
+		NumOutputs:           4,
+		DisableSafetyChecker: true,
 	}
 
-	if MODEL_URL == "" {
-		return g.generateRemote(input)
-	} else {
-		return g.generateLocal(input)
+	// 1st request to launch job
+	response, err := g.postJob(modelInput)
+
+	if err != nil {
+		// TODO: maybe the api needs more time, try again later
+		return []string{}, fmt.Errorf("failed to post job: %s", err)
 	}
 
+	// 2nd request to get job result, eg. output urls
+	getUrl := response.Urls.Get
+
+	tryCount := 0
+
+	responsesUrls, err := g.getResponse(getUrl)
+
+	for err != nil && tryCount < 5 {
+		// maybe the api needs more time, try again later
+		time.Sleep(1 * time.Second)
+		responsesUrls, err = g.getResponse(getUrl)
+	}
+
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to get job response: %s", err)
+	}
+
+	return responsesUrls.Output, nil
 }
 
 type modelInput struct {
-	Prompt              string  `json:"prompt"`
-	Seed                int     `json:"seed,omitempty"`
-	Num_inference_steps int     `json:"num_inference_steps,omitempty"`
-	Guidance_scale      float32 `json:"guidance_scale,omitempty"`
+	Prompt               string `json:"prompt"`
+	NumOutputs           int32  `json:"num_outputs"`
+	DisableSafetyChecker bool   `json:"disable_safety_checker"`
 }
 
 type postResponse struct {
@@ -60,95 +76,6 @@ type postResponse struct {
 type getResponse struct {
 	Output []string `json:"output"`
 	Error  string   `json:"error"`
-}
-
-func (g *imageGenerator) generateLocal(modelInput modelInput) ([]byte, error) {
-
-	input, err := json.Marshal(modelInput)
-
-	if err != nil {
-		return []byte{}, fmt.Errorf("fail to serialize job parameters: %v", err)
-	}
-
-	res, err := http.Post(MODEL_URL, "application/json", strings.NewReader(fmt.Sprintf(`{"input": %s}`, input)))
-
-	if err != nil {
-		return []byte{}, fmt.Errorf("failed to run the model: %s", err)
-
-	}
-
-	defer res.Body.Close()
-
-	body, err := io.ReadAll(res.Body)
-
-	if err != nil {
-		return []byte{}, fmt.Errorf("can't read model response: %s", err)
-
-	}
-
-	type apiResponse struct {
-		Status string   `json:"status"`
-		Output []string `json:"output"` // (base64) data URLs
-	}
-
-	response := apiResponse{}
-
-	json.Unmarshal(body, &response)
-
-	var output string
-	if len(response.Output) > 0 {
-		output = response.Output[0]
-
-		// remove the data URL prefix
-		data := strings.SplitAfter(output, ",")[1]
-
-		decoded, err := base64.StdEncoding.DecodeString(data)
-
-		if err != nil {
-			return []byte{}, fmt.Errorf("can't decode model response: %s", err)
-
-		}
-
-		return decoded, nil
-	} else {
-		return []byte{}, fmt.Errorf("no output in model response")
-	}
-
-}
-
-func (g *imageGenerator) generateRemote(modelInput modelInput) ([]byte, error) {
-
-	// 1st request to launch job
-	response, err := g.postJob(modelInput)
-
-	if err != nil {
-		// TODO: maybe the api needs more time, try again later
-		return []byte{}, fmt.Errorf("failed to post job: %s", err)
-	}
-
-	// 2nd request to get job result, eg. output urls
-	get_url := response.Urls.Get
-
-	output_urls, err := g.getResponse(get_url)
-
-	if err != nil {
-		// TODO: maybe the api needs more time, try again later
-		return []byte{}, fmt.Errorf("failed to get job response: %s", err)
-	}
-
-	// 3rd request to get image(s)
-
-	// TODO: add support for multiple images
-	output_url := output_urls.Output[0]
-
-	data, err := g.getImageData(output_url)
-
-	if err != nil {
-		// TODO: maybe the api needs more time, try again later
-		return []byte{}, fmt.Errorf("failed to get image data: %s", err)
-	}
-
-	return data, nil
 }
 
 func (g *imageGenerator) postJob(modelInput modelInput) (postResponse, error) {
@@ -240,31 +167,4 @@ func (g *imageGenerator) getResponse(url string) (getResponse, error) {
 
 	return resp, nil
 
-}
-
-func (g *imageGenerator) getImageData(url string) ([]byte, error) {
-
-	req, err := http.NewRequest("GET", url, nil)
-
-	if err != nil {
-		return []byte{}, fmt.Errorf("fail to create request: %v", err)
-	}
-
-	req.Header.Add("Authorization", fmt.Sprintf("Token %s", REPLICATE_TOKEN))
-
-	res, err := g.client.Do(req)
-
-	if err != nil {
-		return []byte{}, fmt.Errorf("failed to run the model: %s", err)
-	}
-
-	defer res.Body.Close()
-
-	body, err := io.ReadAll(res.Body)
-
-	if err != nil {
-		return []byte{}, fmt.Errorf("can't read model response: %s", err)
-	}
-
-	return body, nil
 }

--- a/pkg/handlers.go
+++ b/pkg/handlers.go
@@ -31,6 +31,11 @@ func GenerateHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
 		return
 	}
 
+	b.SendChatAction(ctx, &bot.SendChatActionParams{
+		ChatID: message.Chat.ID,
+		Action: "typing",
+	})
+
 	// prompt is message.Text after removing the command
 	prompt := message.Text[(len(GenerateCommand) + 1):]
 	prompt = strings.TrimSpace(prompt)
@@ -57,6 +62,11 @@ func GenerateHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
 		return
 	}
 
+	b.SendChatAction(ctx, &bot.SendChatActionParams{
+		ChatID: message.Chat.ID,
+		Action: "upload_photo",
+	})
+
 	inputMedia := make([]models.InputMedia, 0, len(output))
 
 	for _, image := range output {
@@ -76,24 +86,4 @@ func GenerateHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
 	if err != nil {
 		log.Printf("Error sending photo: %s", err)
 	}
-}
-
-func HelpHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
-
-	if update == nil {
-		log.Println("empty update")
-		return
-	}
-
-	message := update.Message
-
-	if message == nil {
-		log.Println("empty message")
-		return
-	}
-
-	b.SendMessage(ctx, &bot.SendMessageParams{
-		ChatID: message.Chat.ID,
-		Text:   "Hi! I'm a 🤖 that generates images from text. Use the /generate command follow by a prompt, like this: \n\n   /generate a cat in space \n\nHave fun!",
-	})
 }

--- a/pkg/handlers.go
+++ b/pkg/handlers.go
@@ -1,16 +1,13 @@
 package pkg
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log"
-	"path/filepath"
 	"strings"
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
-	"github.com/google/uuid"
 )
 
 type command string
@@ -60,14 +57,20 @@ func GenerateHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
 		return
 	}
 
-	_, err = b.SendPhoto(ctx, &bot.SendPhotoParams{
-		ChatID:  message.Chat.ID,
-		Caption: fmt.Sprint(prompt),
-		Photo: &models.InputFileUpload{
-			Data:     bytes.NewReader(output),
-			Filename: filepath.Base(fmt.Sprintf("%s.png", uuid.New())),
-		},
-		DisableNotification: true,
+	inputMedia := make([]models.InputMedia, 0, len(output))
+
+	for _, image := range output {
+
+		inputMedia = append(inputMedia, &models.InputMediaPhoto{
+			Caption: prompt,
+			Media:   image,
+		})
+	}
+
+	_, err = b.SendMediaGroup(ctx, &bot.
+		SendMediaGroupParams{
+		ChatID: message.Chat.ID,
+		Media:  inputMedia,
 	})
 
 	if err != nil {
@@ -91,6 +94,6 @@ func HelpHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
 
 	b.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID: message.Chat.ID,
-		Text:   "Hi! I'm a 🤖 that generates images from text. Use the /generate command follow by a prompt, like this: \n\n   /generate a cat in space \n\nBy default I will generate 5 images, but you can modify the seed, guidance and steps like so\n\n /generate a cat in space &seed_1234 &steps_50 &guidance_7.5\n\nCheck my status with /status\n\nHave fun!",
+		Text:   "Hi! I'm a 🤖 that generates images from text. Use the /generate command follow by a prompt, like this: \n\n   /generate a cat in space \n\nHave fun!",
 	})
 }


### PR DESCRIPTION
Removing support for local generators. 

Pros:
- makes the bot simpler 
- allows more flexibility on the models the bot can consume
- setup is much easier

Cons:
- makes the bot dependent of replicate.com service
- the image generator costs money
